### PR TITLE
Added nose to test setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,11 @@ install_requires = [
     'pymongo==2.5.1',
     'requests==1.2.2',
     'twisted==13.0.0',
-    'pycurl==7.19.0'
+    'pycurl==7.19.0',
+
 ]
+
+tests_requires = ['nose',]
 
 setup(name="minion-backend",
       version="0.1",
@@ -23,7 +26,8 @@ setup(name="minion-backend",
       packages=['minion', 'minion.backend', 'minion.plugins'],
       namespace_packages=['minion','minion.backend', 'minion.plugins'],
       include_package_data=True,
-      install_requires = install_requires,
+      install_requires = install_requires + tests_requires,
+      tests_requires = tests_requires,
       scripts=['scripts/minion-create-plan',
                'scripts/minion-plugin-worker',
                'scripts/minion-start-scan',


### PR DESCRIPTION
Most people don't use 'python setup.py test' so 'tests_requires' is
included as part of install_requires at installation time. Furthermore,
running 'python setup.py test' will install testing packages locally in
the CWD; doing so will clutter the CWD and may introduce limitations as to how to upgrade testing packages.
