### PR TITLE
Fixed #61. @api_guard takes content-type as argument.

### DIFF
--- a/minion/backend/api.py
+++ b/minion/backend/api.py
@@ -240,7 +240,7 @@ def _check_plan_exists(plan_name):
 # API Methods to manage users
 
 @app.route('/users/<email>', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_user(email):
     email = email.lower()
     user = users.find_one({'email': email})
@@ -308,7 +308,7 @@ def create_user():
 #
 
 @app.route('/users', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def list_users():
     userz = []
     for user in users.find():
@@ -332,7 +332,7 @@ def list_users():
 #
 
 @app.route('/groups', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def list_groups():
     return jsonify(success=True, groups=[sanitize_group(group) for group in groups.find()])
 
@@ -374,7 +374,7 @@ def create_group():
     return jsonify(success=True, group=sanitize_group(new_group))
 
 @app.route('/groups/<group_name>', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_group(group_name):
     group = groups.find_one({'name': group_name})
     if not group:
@@ -388,7 +388,7 @@ def get_group(group_name):
 #
 
 @app.route('/groups/<group_name>', methods=['DELETE'])
-@api_guard('text/plain')
+@api_guard
 def delete_group(group_name):
     group = groups.find_one({'name': group_name})
     if not group:
@@ -456,7 +456,7 @@ def patch_group(group_name):
 #
 
 @app.route('/sites/<site_id>', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_site(site_id):
     site = sites.find_one({'id': site_id})
     if not site:
@@ -532,7 +532,7 @@ def create_site():
 #
 
 @app.route('/sites', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def list_sites():
     sitez = [sanitize_site(site) for site in sites.find()]
     for site in sitez:
@@ -549,7 +549,7 @@ def list_sites():
 # the user can see.
 
 @app.route('/reports/history', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_reports_history():
     history = []
     user_email = request.args.get('user')
@@ -579,7 +579,7 @@ def get_reports_history():
 #    'success': True }
 
 @app.route('/reports/status', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_reports_sites():
     result = []
     user_email = request.args.get('user')
@@ -614,7 +614,7 @@ def get_reports_sites():
 #    'success': True }
 
 @app.route('/reports/issues', methods=['GET'])
-@api_guard('text/plain')
+@api_guard
 def get_reports_issues():
     result = []
     user_email = request.args.get('user')
@@ -655,7 +655,7 @@ def get_reports_issues():
 #
 
 @app.route("/plans")
-@api_guard('text/plain')
+@api_guard
 def get_plans():
     def _plan_description(plan):
         return { 'description': plan['description'], 'name': plan['name'] }
@@ -680,7 +680,7 @@ def get_plans():
 #
 
 @app.route("/plans/<plan_name>")
-@api_guard('text/plain')
+@api_guard
 def get_plan(plan_name):
     plan = plans.find_one({"name": plan_name})
     if not plan:
@@ -702,7 +702,7 @@ def get_plan(plan_name):
 #
 
 @app.route("/plugins")
-@api_guard('text/plain')
+@api_guard
 def get_plugins():
     return jsonify(success=True, plugins=[plugin['descriptor'] for plugin in plugins.values()])
 
@@ -713,7 +713,7 @@ def get_plugins():
 #
 
 @app.route("/scans/<scan_id>")
-@api_guard('text/plain')
+@api_guard
 def get_scan(scan_id):
     scan = scans.find_one({"id": scan_id})
     if not scan:
@@ -726,7 +726,7 @@ def get_scan(scan_id):
 #
 
 @app.route("/scans/<scan_id>/summary")
-@api_guard('text/plain')
+@api_guard
 def get_scan_summary(scan_id):
     scan = scans.find_one({"id": scan_id})
     if not scan:
@@ -787,7 +787,6 @@ def put_scan_create():
     return jsonify(success=True, scan=sanitize_scan(scan))
 
 @app.route("/scans/<scan_id>/control", methods=["PUT"])
-@api_guard('text/plain')
 def put_scan_control(scan_id):
     # Find the scan
     scan = scans.find_one({"id": scan_id})

--- a/minion/backend/tasks.py
+++ b/minion/backend/tasks.py
@@ -286,7 +286,7 @@ class Runner(ProcessProtocol):
 
 
 def get_scan(api_url, scan_id):
-    r = requests.get(api_url + "/scans/" + scan_id, headers={'Content-Type': 'text/json'})
+    r = requests.get(api_url + "/scans/" + scan_id)
     r.raise_for_status()
     j = r.json()
     return j['scan']
@@ -421,7 +421,7 @@ def run_plugin(scan_id, session_id):
 
 
 def get_scan(api_url, scan_id):
-    r = requests.get(api_url + "/scans/" + scan_id, headers={'Content-Type': 'text/plain'})
+    r = requests.get(api_url + "/scans/" + scan_id)
     r.raise_for_status()
     j = r.json()
     return j['scan']

--- a/scripts/minion-scan
+++ b/scripts/minion-scan
@@ -37,8 +37,7 @@ if __name__ == "__main__":
 
    while True:
       
-      r = requests.get(MINION_BACKEND + "/scans/" + scan['id'], 
-              headers={'Content-Type': 'text/plain'})
+      r = requests.get(MINION_BACKEND + "/scans/" + scan['id'])
       r.raise_for_status()
       scan = r.json()['scan']
 

--- a/tests/functional/test_api.py
+++ b/tests/functional/test_api.py
@@ -120,8 +120,7 @@ def _call(task, method, auth=None, data=None, url_args=None, jsonify=True, \
             headers = {'Content-Type': 'application/json', 
                     'X-Minion-Backend-Key': BACKEND_KEY}
         else:
-            headers = {'Content-Type': 'text/plain',
-                    'X-Minion-Backend-Key': BACKEND_KEY}
+            headers = {'X-Minion-Backend-Key': BACKEND_KEY}
     
     if method == 'GET' or method == 'DELETE':
         res = req_objs(api, params=data, auth=auth, headers=headers)


### PR DESCRIPTION
If the content-type does not match with the argument, @api_guard will
abort with HTTP status code 415 media unsupported. A few backend
requests calls have to be modiifed to support this strict content-type
requirement.

Improvement to be made? We probably can subclass app = Flask(**name**)
and use method-based. For example, @app.content_type('text/plain') and
customize @app.route so that by default it checks backend key.
