### PR TITLE
Fixed #77. Removed travis CI badge in favor of drone.io CI badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/mozilla/minion-backend.png)](https://travis-ci.org/mozilla/minion-backend)
+[![Build Status](https://drone.io/github.com/yeukhon/minion-backend/status.png)](https://drone.io/github.com/yeukhon/minion-backend/latest)
 
 This project contains the code for the Minion Backend. It provides an API to create and start scans and the machinery to execute the scan.
 


### PR DESCRIPTION
1. travis is still failing and instead of getting upset we should just remove the icon.
2. travis icon is smaller than drone's, so appearance wise when both are together they look ugly.
