### PR TITLE
Fixed #163. Extended AbstractPlugin with ``get_site_info`` method.

### DIFF
--- a/minion/plugins/base.py
+++ b/minion/plugins/base.py
@@ -5,6 +5,7 @@
 import logging
 import os
 import sys
+import urlparse
 import uuid
 
 from twisted.internet import reactor
@@ -96,8 +97,40 @@ class AbstractPlugin:
     def do_stop(self):
         pass
 
-    # These are simply mapped to the callbacks for convenience
+    def get_site_info(self, std_ports=None):
+        """
+        Parse and retrieve url-based information.
+      
+        Parameters
+        ----------
+        std_ports : optional, dict
+            Default to ``None`` which will use
+            the internal definition: 
+            ``{'http': '80', 'https': 443}``.
 
+        Returns
+        -------
+        info : dict
+            Return a dictionary containing the following
+            keys: ``url, ``netloc``, ``scheme``, ``port``, 
+            ``port`` and ``path``;similar to what 
+            ``urlparse.urlparse`` returns.
+
+        """
+
+        if not std_ports:
+            std_ports = {'http': '80', 'https': 443}
+        url = self.configuration['target']
+        parsed = urlparse.urlparse(url)
+        return {'url': url,
+            'netloc': parsed.netloc,
+            'scheme': parsed.scheme,
+            'hostname': parsed.hostname,
+            'port': parsed.port or std_ports[parsed.scheme],
+            'path': parsed.path}
+    
+    # These are simply mapped to the callbacks for convenience
+    
     def report_start(self):
         self.callbacks.report_start()
 


### PR DESCRIPTION
This method was originally implemented in minion-zap-plugin. But we have
found this method is useful in many plugins and thus we have refactored
this method out of the zap plugin and is now part of the base class,
which is the base class that ExternalProcessPlugin and BlockingPlugin
are based on.

In additional to the original implementation, we now allow
developer to supply `std_port` dictionary, if the developer
needs to determine more ports. Note using `urlparse` can only
read standard url strings. We currently only help determine
the port by http and https as either 80 or 443, respectively.
Some sites still use `8080` as the port for http and some
chooses different port for https.
