### PR TITLE
enable administrator's name with whitespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ After this, visit ``http://localhost:8080`` using a browser and login with the u
 First we need to create a user account by providing a Personal email address, the name of the user and the role of the user, respectively.
 
 ```
-scripts/minion-create-user <your-persona-email-address> "<admin-name>" administrator
+scripts/minion-create-user <your-persona-email-address> '<admin-name>' administrator
 ```
 
 Next, we need to create the plan:

--- a/scripts/minion-db-init
+++ b/scripts/minion-db-init
@@ -26,7 +26,7 @@ if __name__ == "__main__":
     # Create an admin
     email = raw_input("Enter the administrator's Persona email: ")
     name = raw_input("Enter the administrator's name: ")
-    cmd2 = "minion-create-user {email} \"{name}\" administrator".format(email=email, name=name)
+    cmd2 = "minion-create-user {email} '{name}' administrator".format(email=email, name=name)
     p = Popen(shlex.split(cmd2), stdout=PIPE, stderr=PIPE)
     p.communicate()
 


### PR DESCRIPTION
I found a small problem.

At the time create administrative user with `minion-db-init` ,
if username include whitespace,
user did not create and `minion-db-init` end silently.

so that change command usage just same as README
