### PR TITLE
Fixed #204. When building sdist, we must include static files.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include minion *.html *.txt *.yaml *.yml *.json *.j2


### PR DESCRIPTION
We are including yaml, json and Jinja2 files because these are
usually the most popular data/template file extensions.
