### PR TITLE
Fixed #215. Allow to query report status and issue by group_name.

### DIFF
--- a/minion/backend/views/users.py
+++ b/minion/backend/views/users.py
@@ -10,8 +10,16 @@ from minion.backend.views.base import api_guard, groups, sites, users
 from minion.backend.views.groups import _check_group_exists
 
 def _find_groups_for_user(email):
-    """Find all the groups the user is in"""
+    """Find all the groups the user is in. """
     return [g['name'] for g in groups.find({"users":email})]
+
+def _find_sites_for_user_by_group_name(email, group_name):
+    """ Find all sites that user has access to in a
+    given group. """
+    group = groups.find_one({'name': group_name, 'users': email})
+    if not group:
+        return jsonify(success=False, reason="Group not found.")
+    return group['sites']
 
 def _find_sites_for_user(email):
     """Find all sites that the user has access to"""

--- a/tests/functional/views/base.py
+++ b/tests/functional/views/base.py
@@ -359,16 +359,20 @@ class TestAPIBaseClass(unittest.TestCase):
             data = {'user': user}
         return _call('history', 'GET', data=data, jsonify=False)
 
-    def get_reports_status(self, user=None):
+    def get_reports_status(self, user=None, group_name=None):
         data = None
         if user is not None:
             data = {'user': user}
+            if group_name is not None:
+                data.update({'group_name': group_name})
         return _call('status', 'GET', data=data, jsonify=False)
 
-    def get_reports_issues(self, user=None):
+    def get_reports_issues(self, user=None, group_name=None):
         data = None
         if user is not None:
             data = {'user': user}
+            if group_name is not None:
+                data.update({'group_name': group_name})
         return _call('issues', 'GET', data=data, jsonify=False)
 
     def _test_keys(self, target, expected):

--- a/tests/functional/views/test_groups.py
+++ b/tests/functional/views/test_groups.py
@@ -73,6 +73,30 @@ class TestGroupAPIs(TestAPIBaseClass):
         self.assertEqual(res2.json()['group']['name'], self.group_name)
         self.assertEqual(res2.json()['group']['description'], self.group_description)
 
+    # issue #215
+    def test_retrieve_issue_status_and_issues_by_group(self):
+        """ Don't be shock. This test fits here; by querying
+        user and group, we should only be given the lastest
+        issue status. """
+
+        res = self.create_user()
+        res1 = self.create_group(group_name="test1", users=[self.email])
+        res2 = self.create_group(group_name="test2", users=[self.email])
+        res3 = self.create_site(groups=["test1"], site="http://foo.com")
+        res4 = self.create_site(groups=["test2"], site="http://bar.com")
+        raw_input("----")
+        # if we query just test1, should get back only foo.com
+        res5 = self.get_reports_status(user=self.email, group="test1")
+        r = res5.json()['report']
+        self.assertEqual(len(r), 1) # there should just be one dict returned in the list
+        self.assertEqual(r[0]['target'], "http://foo.com")
+    
+        # if we try it on get_report_issues we should see similar result
+        res6 = self.get_report_issues(user=self.email, group="test1")
+        r = res6.json()['report']
+        self.assertEqual(len(r), 1) # there should just be one dict returned in the list
+        self.assertEqual(r[0]['target'], "http://foo.com")
+
     def test_delete_group(self):
         res = self.create_user()
         res1 = self.create_group()

--- a/tests/functional/views/test_plans.py
+++ b/tests/functional/views/test_plans.py
@@ -9,12 +9,11 @@ from base import BACKEND_KEY, BASE, _call, TestAPIBaseClass
 class TestPlanAPIs(TestAPIBaseClass):
 
     PLAN = { "name": "test",
-              "description": "Test",
-              "workflow": [ { "plugin_name": "minion.plugins.basic.AlivePlugin",
-                              "description": "Test if the site is alive",
-                              "configuration": { "foo": "bar" }
-                              } ] }
-
+                      "description": "Test",
+                      "workflow": [ { "plugin_name": "minion.plugins.basic.AlivePlugin",
+                                      "description": "Test if the site is alive",
+                                      "configuration": { "foo": "bar" }
+                                      } ] }
     def _create_plan(self, plan):
         res1 = self.create_user(email=self.email)
         res2 = self.create_group(users=[self.email,], group_name='test_group')

--- a/tests/functional/views/test_reports.py
+++ b/tests/functional/views/test_reports.py
@@ -1,0 +1,40 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import pprint
+import requests
+
+from base import BACKEND_KEY, BASE, _call, TestAPIBaseClass
+
+class TestReportsAPIs(TestAPIBaseClass):
+
+    PLAN = { "name": "test",
+                          "description": "Test",
+                          "workflow": [ { "plugin_name": "minion.plugins.basic.AlivePlugin",
+                                          "description": "Test if the site is alive",
+                                          "configuration": { "foo": "bar" }
+                                          } ] }
+    # issue #215
+    def test_retrieve_issue_status_and_issues_by_group(self):
+        """ Don't be shock. This test fits here; by querying
+        user and group, we should only be given the lastest
+        issue status. """
+
+        res = self.create_user()
+        res1 = self.create_plan(self.PLAN)
+        res2 = self.create_group(group_name="test1", users=[self.email])
+        res3 = self.create_group(group_name="test2", users=[self.email])
+        res4 = self.create_site(groups=["test1"], site="http://foo.com", plans=["test"])
+        res5 = self.create_site(groups=["test2"], site="http://bar.com", plans=["test"])
+        # if we query just test1, should get back only foo.com
+        res6 = self.get_reports_status(user=self.email, group_name="test1")
+        r = res6.json()['report']
+        self.assertEqual(len(r), 1) # there should just be one dict returned in the list
+        self.assertEqual(r[0]['target'], "http://foo.com")
+
+        # if we try it on get_report_issues we should see similar result
+        res7 = self.get_reports_issues(user=self.email, group_name="test1")
+        r = res7.json()['report']
+        self.assertEqual(len(r), 1) # there should just be one dict returned in the list
+        self.assertEqual(r[0]['target'], "http://foo.com")

--- a/tests/functional/views/test_users.py
+++ b/tests/functional/views/test_users.py
@@ -257,4 +257,3 @@ class TestGroupAPIs(TestAPIBaseClass):
         self._test_keys(res2.json().keys(), set(res1.json().keys()))
         self._test_keys(res2.json()['group'].keys(), set(res1.json()['group'].keys()))
         self.assertEqual(res2.json()['group']['users'], [])
-


### PR DESCRIPTION
To query the group, we right now restrict the query must have
a user query appended as well..
