### PR TITLE
Fixed #228. Remove kill_ports from functional tests.

### DIFF
--- a/tests/functional/plugins/base.py
+++ b/tests/functional/plugins/base.py
@@ -13,11 +13,6 @@ from subprocess import Popen, PIPE
 from flask import Flask
 test_app = Flask(__name__)
 
-def _kill_ports(ports):
-    for port in ports:
-        p = Popen(['sudo', '/bin/kill `sudo lsof -t -i:%s`' %str(port)],\
-                stdout=PIPE, stderr=PIPE, shell=True)
-
 class TestPluginBaseClass(unittest.TestCase):
     __test__ = False
     PORTS = (1234, 1235, 1443)
@@ -30,7 +25,6 @@ class TestPluginBaseClass(unittest.TestCase):
         def run_app():
             test_app.run(host='localhost', port=1234)
 
-        _kill_ports(cls.PORTS)
         # use multiprocess to launch server and kill server
         cls.server = Process(target=run_app)
         cls.server.daemon = True
@@ -40,7 +34,6 @@ class TestPluginBaseClass(unittest.TestCase):
     def tearDownClass(cls):
         cls.server.terminate()
         time.sleep(2)
-        _kill_ports(cls.PORTS)  # just in case
 
     def run_plugin(self, pname, api):
         pname = "minion.plugins.basic." + pname
@@ -49,8 +42,6 @@ class TestPluginBaseClass(unittest.TestCase):
                 "-p", pname]
         p = Popen(cmd, stdout=PIPE, stderr=PIPE)
         stdout, stderr = p.communicate()
-        print stdout
-        print stderr
         msgs = stdout.split('\n')[:-1]
         msgs_lst = []
         for msg in msgs:

--- a/tests/functional/plugins/test_hsts.py
+++ b/tests/functional/plugins/test_hsts.py
@@ -12,7 +12,7 @@ from subprocess import Popen, PIPE
 
 from flask import make_response
 
-from base import TestPluginBaseClass, test_app, _kill_ports
+from base import TestPluginBaseClass, test_app
 
 @test_app.route('/has-hsps')
 def has_hsps():
@@ -56,7 +56,6 @@ class TestHSTSPlugin(TestPluginBaseClass):
                 stderr=PIPE)
             p.communicate()
 
-        _kill_ports(cls.PORTS)
         cls.stunnel = Process(target=run_stunnel)
         cls.stunnel.daemon = True
         cls.stunnel.start()
@@ -71,8 +70,6 @@ class TestHSTSPlugin(TestPluginBaseClass):
     def tearDownClass(cls):
         cls.server1.terminate()
         cls.stunnel.terminate() # only kills multiprocess instance
-        # actually kills stunnel process
-        _kill_ports(cls.PORTS)
 
     def validate_hsps(self, runner_resp, request_resp, expected=None, expectation=True):
         if expectation is True:

--- a/tests/functional/plugins/test_robot.py
+++ b/tests/functional/plugins/test_robot.py
@@ -5,7 +5,7 @@
 from flask import Flask, make_response, redirect, url_for
 from multiprocessing import Process
 
-from base import TestPluginBaseClass, test_app, _kill_ports
+from base import TestPluginBaseClass, test_app
 
 @test_app.route('/robots.txt')
 def robot():
@@ -36,7 +36,6 @@ class TestRobotsPlugin(TestPluginBaseClass):
             test_app = APPS[app]
             test_app.run(host='localhost', port=port)
 
-        _kill_ports(cls.PORTS)
         cls.server1 = Process(target=run_app, args=(1234, 'test_app',))
         cls.server2 = Process(target=run_app, args=(1235, 'test2_app',))
         cls.server3 = Process(target=run_app, args=(1443, 'test3_app',))

--- a/tests/functional/views/test_scans.py
+++ b/tests/functional/views/test_scans.py
@@ -26,26 +26,18 @@ class TestScanAPIs(TestAPIBaseClass):
     def setUp(self):
         super(TestScanAPIs, self).setUp()
         self.import_plan()
-
-    def _kill_ports(self, ports):
-        for port in ports:
-            p = Popen(['kill `fuser -n tcp %s`' % str(port)],\
-                    stdout=PIPE, stderr=PIPE, shell=True)
-            p.communicate()
-    
+ 
     def start_server(self):
         ''' Similar to plugin functional tests, we need
-        to start server and kill ports. '''
+        to start server.'''
         def run_app():
             test_app.run(host='localhost', port=1234)
-        self._kill_ports([1234,])
         self.server = Process(target=run_app)
         self.server.daemon = True
         self.server.start()
        
     def stop_server(self):
         self.server.terminate()
-        self._kill_ports([1234,])    
 
     def test_create_scan_with_credential(self):
         res1 = self.create_user(email=self.email)


### PR DESCRIPTION
Since #226 is fixed, we can actually tearDown and stop running
flask instance during test, we don't need this kill port hack.
https://github.com/mozilla/minion-backend/commit/bb94e17ae778db3f7d168e0a8f6b3835340dd1bb
