### PR TITLE
Refactor invite

### DIFF
--- a/tests/functional/views/base.py
+++ b/tests/functional/views/base.py
@@ -46,6 +46,8 @@ APIS = {'users':
             {'POST': '/invites/{id}/control',
              'GET': '/invites/{id}',
              'DELETE': '/invites/{id}'},
+        'resend_invite':
+            {'POST': '/invites/{id}/resend'},
         'groups':
             {'POST': '/groups',
               'GET': '/groups'},
@@ -245,6 +247,9 @@ class TestAPIBaseClass(unittest.TestCase):
     def get_invite(self, id):
         return _call('invite', 'GET', url_args={'id': id})
 
+    def resend_invite(self, id):
+        return _call('resend_invite', 'POST', 
+            url_args={'id': id}, data={'base_url': "http://localhost:8080"})
     def update_invite(self, id, resend=None, accept=None, decline=None, base_url="http://localhost:8080", login=None):
         if resend:
             data = {'action': 'resend', "base_url": base_url}

--- a/tests/functional/views/base.py
+++ b/tests/functional/views/base.py
@@ -48,6 +48,8 @@ APIS = {'users':
              'DELETE': '/invites/{id}'},
         'resend_invite':
             {'POST': '/invites/{id}/resend'},
+        'decline_invite':
+            {'POST': '/invites/{id}/decline'},
         'groups':
             {'POST': '/groups',
               'GET': '/groups'},
@@ -250,13 +252,13 @@ class TestAPIBaseClass(unittest.TestCase):
     def resend_invite(self, id):
         return _call('resend_invite', 'POST', 
             url_args={'id': id}, data={'base_url': "http://localhost:8080"})
-    def update_invite(self, id, resend=None, accept=None, decline=None, base_url="http://localhost:8080", login=None):
-        if resend:
-            data = {'action': 'resend', "base_url": base_url}
-        elif accept:
+    
+    def decline_invite(self, id):
+        return _call('decline_invite', 'POST', url_args={'id': id})
+
+    def update_invite(self, id, accept=None, base_url="http://localhost:8080", login=None):
+        if accept:
             data = {'action': 'accept'}
-        elif decline:
-            data = {'action': 'decline'}
         if login:
             data.update({'login': login})
         return _call('invite', 'POST', url_args={'id': id}, data=data)

--- a/tests/functional/views/base.py
+++ b/tests/functional/views/base.py
@@ -43,9 +43,10 @@ APIS = {'users':
             {'POST': '/invites',
              'GET': '/invites'},
         'invite': 
-            {'POST': '/invites/{id}/control',
-             'GET': '/invites/{id}',
+            {'GET': '/invites/{id}',
              'DELETE': '/invites/{id}'},
+        'accept_invite':
+            {'POST': '/invites/{id}/accept'},
         'resend_invite':
             {'POST': '/invites/{id}/resend'},
         'decline_invite':
@@ -249,19 +250,18 @@ class TestAPIBaseClass(unittest.TestCase):
     def get_invite(self, id):
         return _call('invite', 'GET', url_args={'id': id})
 
+    def accept_invite(self, id, login=None):
+        data = {'base_url': "http://localhost:8080"}
+        if login:
+            data.update({'login': login})
+        return _call('accept_invite', 'POST', url_args={'id': id}, data=data)
+
     def resend_invite(self, id):
         return _call('resend_invite', 'POST', 
             url_args={'id': id}, data={'base_url': "http://localhost:8080"})
     
     def decline_invite(self, id):
         return _call('decline_invite', 'POST', url_args={'id': id})
-
-    def update_invite(self, id, accept=None, base_url="http://localhost:8080", login=None):
-        if accept:
-            data = {'action': 'accept'}
-        if login:
-            data.update({'login': login})
-        return _call('invite', 'POST', url_args={'id': id}, data=data)
 
     def delete_invite(self, id):
         return _call('invite', 'DELETE', url_args={'id': id})

--- a/tests/functional/views/test_invites.py
+++ b/tests/functional/views/test_invites.py
@@ -287,7 +287,7 @@ class TestInviteAPIs(TestAPIBaseClass):
         # send invitation
         res3 = self.create_invites(recipient=recipient1, sender=self.email)
         invite_id = res3.json()['invite']['id']
-        res4 = self.update_invite(invite_id, accept=True, login=recipient1)
+        res4 = self.accept_invite(invite_id, login=recipient1)
         # check user is no longer invited
         res5 = self.get_user(recipient1)
         self.assertEqual(res5.json()['user']['email'], recipient1)
@@ -330,7 +330,7 @@ class TestInviteAPIs(TestAPIBaseClass):
         invite_id = res5.json()['invite']['id']
 
         # accept invite and login with a different email
-        res6 = self.update_invite(invite_id, accept=True, login=persona)
+        res6 = self.accept_invite(invite_id, login=persona)
         self.assertEqual(res6.json()['success'], True)
 
         # this should raise not found
@@ -382,7 +382,7 @@ class TestInviteAPIs(TestAPIBaseClass):
         invite_id = res8.json()['invite']['id']
 
         # accept invite and login with a different email (and this email already exists)
-        res9 = self.update_invite(invite_id, accept=True, login=existing_user)
+        res9 = self.accept_invite(invite_id, login=existing_user)
         self.assertEqual(res9.json()['success'], True)
 
         # this should raise not found

--- a/tests/functional/views/test_invites.py
+++ b/tests/functional/views/test_invites.py
@@ -193,8 +193,7 @@ class TestInviteAPIs(TestAPIBaseClass):
         res1 = self.create_user(email=recipient, name='Alice', invitation=True)
 
         res2 = self.create_invites(recipient=recipient, sender=self.email)
-        res3 = self.update_invite(id=res2.json()['invite']['id'],
-                resend=True)
+        res3 = self.resend_invite(id=res2.json()['invite']['id'])
         # should not equal
         self.assertNotEqual(res2.json(), res3.json())
         self.assertNotEqual(res2.json()['invite']['id'], res3.json()['invite']['id'])

--- a/tests/functional/views/test_invites.py
+++ b/tests/functional/views/test_invites.py
@@ -212,8 +212,9 @@ class TestInviteAPIs(TestAPIBaseClass):
         self.assertEqual(res4.json()['user']['groups'], ['test_group'])
 
         res5 = self.create_invites(recipient=recipient, sender=self.email)
-        res6 = self.update_invite(id=res5.json()['invite']['id'],
-                decline=True)
+        #res6 = self.update_invite(id=res5.json()['invite']['id'],
+        #        decline=True)
+        res6 = self.decline_invite(id=res5.json()['invite']['id'])
         self.assertEqual(res6.json()['invite']['status'], 'declined')
 
         # check user is no longer in the group (bug #175)


### PR DESCRIPTION
Finally got a few hours tonight to finish this! Refactoring went pretty smoothly. Manual testing is time consuming.
- refactored the invites/control into resend, decline and accept apis
- refactored common code into load_user_and_invite and invite_has_expird
- extend invite lifetime when resend instead of issuing a new id

This requires https://github.com/mozilla/minion-frontend/pull/140 to be pulled in.
