### PR TITLE
Fixed #279. Rewrite CSPPlugin.

### DIFF
--- a/minion/plugins/basic.py
+++ b/minion/plugins/basic.py
@@ -4,6 +4,7 @@
 
 
 import collections
+import copy
 import logging
 import os
 import re
@@ -11,6 +12,7 @@ import time
 import sys
 import urlparse
 
+from collections import namedtuple
 from twisted.internet.task import LoopingCall
 from robots_scanner.scanner import scan
 
@@ -545,6 +547,13 @@ class RobotsPlugin(BlockingPlugin):
             self.report_issues([self._format_report('invalid')])
 
 
+def format_report(self, issue_key, format_list):
+    issue = copy.deepcopy(self.REPORTS[issue_key])
+    for component in format_list:
+        for component_name, kwargs in component.items():
+            issue[component_name] = issue[component_name].format(**kwargs)
+    return issue
+
 #
 # CSPPlugin
 #
@@ -576,95 +585,171 @@ class CSPPlugin(BlockingPlugin):
         },
 ]
 
-    REPORTS = {
-        "set":
-        {
-            "Code": "CSP-0",
-            "Summary": "Content-Security-Policy header set properly",
-            "Description": "The Content-Security-Policy header is set properly. Neither 'unsafe-inline' or \
-'unsafe-eval' is enabled.",
-            "Severity": "Info",
-            "URLs": [ {"URL": None, "Extra": None} ],
-            "FurtherInfo": FURTHER_INFO
-         },
-         "not-set":
-         {
-             "Code": "CSP-1",
-             "Summary": "No Content-Security-Policy header set",
-             "Description": "Site has no Content-Security Policy header set. CSP defines the Content-Security-Policy \
-HTTP header that allows you to create a whitelist of sources of trusted content, and instructs the browser to only \
-execute or render resources from those sources.",
-             "Severity": "High",
-             "URLs": [ {"URL": None, "Extra": None} ],
-             "FurtherInfo": FURTHER_INFO
-         },
-         "report-mode":
-         {
-             "Code": "CSP-2",
-            "Summary": "Content-Security-Policy-Report-Only header set",
-            "Description": "Content-Security-Policy-Report-Only does not enforce any CSP policy. Use \
-Content-Security-Policy to secure your site.",
-            "Severity": "High",
-            "URLs": [ {"URL": None, "Extra": None}],
-            "FurtherInfo": FURTHER_INFO
-         },
-         "dual-policy":
-         {
-             "Code": "CSP-3",
-            "Summary": "Content-Security-Policy-Report-Only and Content-Security-Policy are set",
-            "Description": "While browsers will honored both headers (polices specify in Content-Security-Policy \
-are enforced), it is recommended to remove report-only header from production site",
-            "Severity": "High",
-            "URLs": [ {"URL": None, "Extra": None}],
-            "FurtherInfo": FURTHER_INFO
-         },
-         "unprefixed":
-         {
-             "Code": "CSP-4",
-            "Summary": "X-Content-Security-Policy header is set",
-            "Description": "While browsers still support prefixed CSP, it is recommended to use the unprefixed version \
-by setting Content-Security-Policy in the header only.",
-            "Severity": "High",
-            "URLs": [ {"URL": None, "Extra": None}],
-            "FurtherInfo": FURTHER_INFO
-         },
-         "malformed":
-         {
-             "Code": "CSP-5",
-            "Summary": "Malformed Content-Security-Policy header is set",
-            "Description": "",
-            "Severity": "High",
-            "URLs": [ {"URL": None, "Extra": None}],
-            "FurtherInfo": FURTHER_INFO
-         },
-         "unsafe":
-         {
-             "Code": "CSP-6",
-            "Summary": "{directive} is set in Content-Security-Policy header",
-            "Description": "By enabling either 'unsafe-inline' or 'unsafe-eval' can open ways for inline script injection \
-(both style and javascript) and malicious script execution, respectively.",
-            "Severity": "High",
-            "URLs": [ {"URL": None, "Extra": None}],
-            "FurtherInfo": FURTHER_INFO
-         },
+    DESCRIPTIONS = {
+        "csp": "Content-Security-Policy (CSP) is an added layer of security that helps to detect and mitigate certain \
+types of attacks, including Cross Site Scripting (XSS) and data injection attacks. These attacks are used for \
+everything from data theft to site defacement or distribution of malware.",
+        "xcsp": "X-Content-Security-Policy header is now being deprecated by major browsers such as Firefox, Chrome and \
+Opera. It is advised to add Content-Security-Policy header (currently is at 1.0 spec) for users using newer verions of \
+browsers, and keep the X-Content-Security-Policy header intact so users who are using out-of-date browsers that support \
+CSP can still benefit from the X-CSP protection.",
+        "report-only": "The X/Content-Security-Policy-Report-Only header lets the developers to experiment CSP settings \
+rather than actually enforcing the policy settings. Missing X/Content-Security-Policy is the same as not having CSP \
+in the first place.",
+        "unknown-directive": "This plugin checks CSP based on 1.0 specification. CSP 1.1 is a draft version and not all \
+browsers support every feature of CSP 1.1. If this scan session has marked CSP 1.1 rules as invalid, you may ignore \
+those warnings.",
+        "unsafe-inline": "Unless specified in default-src or in script-src or in style-src, inline Javascript and inline \
+CSS are not permitted. This default behavior is introduced to mitigate the risk of scripting attacks such as \
+Cross Site Scripting (XSS) which take advantage of executing inline Javascript or CSS code during user time. By \
+specifying 'unsafe-inline', inline scripting attack may be possible.",
+        "unsafe-eval": "Unless specified in default-src or in script-src or in style-src, the eval() function is disabled \
+to prevent creating and executing code from string, which is commonly used to create Cross Site Scripting (XSS) vector in \
+XSS attack.",
+        "none": "CSP allows developers to specify a whitelist of trusted source origins. For example, specifying \
+img-src foobar.com means images can only be loaded from foobar.com. 'none' is a special keyword to indicate that no \
+sources can be used for loading for the corresponding directive. For example, if an application does not need iframe, \
+specifying frame-src 'none' will disallow iframe from being loaded on the target site. When 'none' is present, other \
+sources must not be included in the whitelist of the corresponding directive.",
+        "allow": "The current CSP 1.0 spec has renamed the directive 'allow' to 'default-src'. The deprecated header, \
+X-Content-Security-Policy, works with the deprecated directive 'allow'.",
+        "xhr-src": "The current CSP 1.0 spec has renamed the directive 'xhr-src' to 'connect-src'. The deprecated \
+header, X-Content-Security-Policy, works with the deprecated directive 'xhr-connect'.",
+}
 
+    REPORTS = {
+        "csp-set":
+        {
+            "Code": "CSP-1",
+            "Summary": "Content-Security-Policy header is set",
+            "Description": DESCRIPTIONS['csp'],
+            "Severity": "Info",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "csp-not-set":
+        {
+            "Code": "CSP-2",
+            "Summary": "Content-Security-Policy header is not set",
+            "Description": DESCRIPTIONS['csp'],
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "csp-ro-only-set":
+        {
+            "Code": "CSP-3",
+            "Summary": "Content-Security-Policy-Report-Only header is set but CSP is missing",
+            "Description": DESCRIPTIONS['report-only'],
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "xcsp-set":
+        {
+            "Code": "CSP-4",
+            "Summary": "X-Content-Security-Policy header is set",
+            "Description": DESCRIPTIONS['xcsp'],
+            "Severity": "Info",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "xcsp-not-set":
+        {
+            "Code": "CSP-5",
+            "Summary": "X-Content-Security-Policy header is not set",
+            "Description": DESCRIPTIONS['xcsp'],
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "xcsp-ro-only-set":
+        {
+            "Code": "CSP-6",
+            "Summary": "X-Content-Security-Policy-Report-Only header is set but X-CSP is missing",
+            "Description": DESCRIPTIONS['report-only'],
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "csp-csp-ro-set":
+        {
+            "Code": "CSP-7",
+            "Summary": "Both Content-Security-Policy and Report-Only headers are set",
+            "Description": "description of daul policy.",
+            "Severity": "Info",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "xcsp-xcsp-ro-set":
+        {
+            "Code": "CSP-8",
+            "Summary": "Both X-Content-Security-Policy and Report-Only headers are set",
+            "Description": "description of daul policy",
+            "Severity": "Info",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "unknown-directive":
+        {
+            "Code": "CSP-9",
+            "Summary": "Found {count} unrecongized CSP directives",
+            "Description": DESCRIPTIONS['unknown-directive'] + 
+                           "The followings are the list of unrecongized CSP directives:\n{policies}",
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "deprecated-directive":
+        {
+            "Code": "CSP-10",
+            "Summary": "Found {count} deprecated CSP directives",
+            "Description": "{description}",
+            "Solution": "{solution}",
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "bad-none":
+        {
+            "Code": "CSP-11",
+            "Summary": "When 'none' is specify, no other source expressions can be specified",
+            "Description": DESCRIPTIONS['none'] + "The following directives specify 'none' and other sources:\n{directives}",
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "inline":
+        {
+            "Code": "CSP-12",
+            "Summary": "unsafe-inline is enabled",
+            "Description": DESCRIPTIONS['unsafe-inline'] + "The following policies have unsafe-inline specified:\n{policies}",
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
+        "eval":
+        {
+            "Code": "CSP-13",
+            "Summary": "unsafe-eval is enabled",
+            "Description": DESCRIPTIONS['unsafe-eval'] + "The following policies have unsafe-eval specified:\n{policies}",
+            "Severity": "High",
+            "URLs": [ {"URL": None, "Extra": None}],
+            "FurtherInfo": FURTHER_INFO
+        },
     }
     SCHEME_SOURCE = r"(https|http|data|blob|javascript|ftp)\:"
     HOST_SOURCE = r'((https|http|data|blob|javascript|ftp)\:\/\/)?((\*\.)?[a-z0-9\-]+(\.[a-z0-9\-]+)*|\*)(\:(\*|[0-9]+))?'
     KEYWORD_SOURCE = r"('self'|'unsafe-inline'|'unsafe-eval')"
-
-    def _extract_csp_header(self, headers, keys_tuple):
-        keys = set(headers)
-        matches = keys.intersection(keys_tuple)
-        name = None
-        value = None
-        if len(matches) == 2:
-            name = keys_tuple[0]
-            value = headers[name]
-        elif matches:
-            name = matches.pop()
-            value = headers[name]
-        return name, value
+    DIRECTIVES = ("default-src", "script-src", "style-src", "object-src", "img-src", \
+        "media-src", "frame-src", "font-src", "connect-src", "report-uri")
+    DEPRECATED_DIRECTIVES = ("allow", "xhr-src")
+    DEPRECATED_DIRECTIVES_PAIR = dict(zip(DEPRECATED_DIRECTIVES, ["default-src", "connect-src"]))
+    DESCRIPTIONS = {
+        "allow": "allow is deprecated and should be replace with default-src.",
+        "xhr-src": "xhr-connect is a deprecated directive name. Use connect-src for CSP 1.0 compliance."
+    }
+    Policy = namedtuple('Policy', 'directive source_list str')
 
     def _match(self, uri, regex):
         r = re.compile(regex)
@@ -674,61 +759,131 @@ by setting Content-Security-Policy in the header only.",
         else:
             return False
 
-    def _parse_csp(self, csp):
-        options = collections.defaultdict(list)
-        p = re.compile(r';\s*')
-        for rule in p.split(csp):
-            a = rule.split()
-            if a:
-                values = a[1:]
-                for value in values:
-                    if value in ("'none'", "*"):
-                        if len(values) > 2:
-                            raise ValueError("When %s is present, other values cannot co-exist with %s" %(value, value))
-                    elif value not in ("'self'", "'unsafe-inline'", "'unsafe-eval'", "'https:'", "'https'"):
-                        if not self._match(value, self.SCHEME_SOURCE) and \
-                           not self._match(value, self.KEYWORD_SOURCE) and \
-                           not self._match(value, self.HOST_SOURCE):
-                            raise ValueError("%s does not seem like a valid source expression for %s" % (value, a[0]))
-                    elif value == "'unsafe-inline'" or value == "'unsafe-eval'":
-                        issue = self._format_report('unsafe')
-                        issue['Summary'] = issue['Summary'].format(directive=value)
-                        self.report_issue(issue)
-                options[a[0]] += a[1:]
-        return options
+    def _check_headers(self, headers):
+        # get the header names
+        headers = set(headers)
+        csp = csp_ro = xcsp = xcsp_ro = False
+        if "content-security-policy" in headers:
+            csp = True
+        if "content-security-policy-report-only" in headers:
+            csp_ro = True
+        if "x-content-security-policy" in headers:
+            xcsp = True
+        if "x-content-security-policy-report-only" in headers:
+            xcsp_ro = True
+
+        if csp:
+            self.report_issues([self._format_report('csp-set')])
+        else:
+            self.report_issues([self._format_report('csp-not-set')])
+
+        if csp and csp_ro:
+            self.report_issues([self._format_report('csp-csp-ro-set')])
+        elif csp_ro and not csp:
+            self.report_issues([self._format_report('csp-ro-only-set')])
+
+        if xcsp:
+            self.report_issues([self._format_report('xcsp-set')])
+        else:
+            self.report_issues([self._format_report('xcsp-not-set')])
+
+        if xcsp and xcsp_ro:
+            self.report_issues([self._format_report('xcsp-xcsp-ro-set')])
+        elif xcsp_ro and not xcsp:
+            self.report_issues([self._format_report('xcsp-ro-only-set')])
+
+    def _split_policy(self, csp):
+        r1 = re.compile(';\s*')
+        r2 = re.compile('\s+')
+
+        # individual directives should be split by ;
+        dir_split_list = r1.split(csp)
+        # the last item could be empty if ; is present
+        dir_split_list = filter(None, dir_split_list)
+        
+        # split by space so directive name is first element
+        # follows by a list of source expressions
+        self.policies = []
+        for index, directive_group in enumerate(dir_split_list):
+            d = r2.split(directive_group)
+            self.policies.append(self.Policy(d[0], d[1:], " ".join(d)))
+
+    def _check_directives(self):
+        depr_dirs = []
+        unknown_dirs = []
+        for policy in self.policies:
+            if policy.directive in self.DEPRECATED_DIRECTIVES:
+                depr_dirs.append(policy)
+            elif policy.directive not in self.DIRECTIVES:
+                unknown_dirs.append(policy)
+        if unknown_dirs:
+            unknown_s = "\n".join(p.str for p in unknown_dirs)
+            self.report_issues([
+                format_report(self, 'unknown-directive', [
+                    {'Summary': {"count": len(unknown_dirs)}},
+                    {"Description": {"policies": unknown_s}}
+                ])
+            ])
+
+        if depr_dirs:
+            solutions = []
+            descriptions = []
+            for policy in depr_dirs:
+                replacement = self.DEPRECATED_DIRECTIVES_PAIR[policy.directive]
+                new_policy = " ".join([replacement] + policy.source_list)
+                solution_str = "Replace {old_policy} with {new_policy}".format(
+                    old_policy=policy.str, new_policy=new_policy)
+                descriptions.append(self.DESCRIPTIONS[policy.directive])
+                solutions.append(solution_str)
+            self.report_issues([
+                format_report(self, 'deprecated-directive', [
+                    {'Summary': {"count": len(depr_dirs)}},
+                    {"Description": {"description": "\n".join(descriptions)}},
+                    {"Solution": {"solution": "\n".join(solutions)}}
+                ])
+            ])
+    def _check_source_lists(self):
+        bad_none = []
+        inline = []
+        eval = []
+        for policy in self.policies:
+            if "'none'" in policy.source_list:
+                if len(policy.source_list) > 1:
+                    bad_none.append(policy)
+                    # something bad so skip to next directive
+                    continue
+            if policy.directive in ('style-src', 'script-src'):
+                if "'unsafe-inline'" in policy.source_list:
+                    inline.append(policy)
+                if "'unsafe-eval'" in policy.source_list:
+                    eval.append(policy)
+        if bad_none:
+            self.report_issues([
+                format_report(self, 'bad-none', [
+                    {'Summary': {'count': len(bad_none)}},
+                    {'Description': {'directives': str(bad_none)}}
+                ])
+            ])
+        if inline:
+            self.report_issues([
+                format_report(self, 'inline', [
+                    {'Description': {"policies": "\n".join(p.str for p in inline)}}
+                ])
+            ])
+        if eval:
+            self.report_issues([
+                format_report(self, 'eval', [
+                    {'Description': {"policies": "\n".join(p.str for p in eval)}}
+                ])
+            ])
 
     def do_run(self):
-        GOOD_HEADERS = ('x-content-security-policy', 'content-security-policy',)
-        BAD_HEADERS = ('x-content-security-policy-report-only', \
-                'content-security-policy-report-only',)
         r = minion.curly.get(self.configuration['target'], connect_timeout=5, timeout=15)
         r.raise_for_status()
 
-        csp_hname, csp = self._extract_csp_header(r.headers, GOOD_HEADERS)
-        csp_ro_name, csp_report_only = self._extract_csp_header(r.headers, BAD_HEADERS)
-
-        # Fast fail if both headers are set
-        if csp and csp_report_only:
-            self.report_issues([self._format_report('dual-policy')])
-            return
-
-        # Fast fail if only reporting is enabled
-        if csp_report_only:
-            self.report_issues([self._format_report('report-mode')])
-            return
-
-        # Fast fail if no CSP header is set
-        if csp is None:
-            self.report_issues([self._format_report('not-set')])
-            return
-
-        # Parse the CSP and look for issues
-        try:
-            csp_config = self._parse_csp(csp)
-            if not csp_config:
-                self.report_issues([self._format_report('malformed', description=csp_hname)])
-                return
-            else:
-                self.report_issues([self._format_report('set')])
-        except ValueError as e:
-            self.report_issues([self._format_report('malformed', description='Malformed CSP header set: ' + str(e))])
+        self._check_headers(r.headers)
+        if "content-security-policy" in r.headers:
+            csp = r.headers["content-security-policy"]
+            self._split_policy(csp)
+            self._check_directives()
+            self._check_source_lists()

--- a/tests/functional/plugins/test_csp.py
+++ b/tests/functional/plugins/test_csp.py
@@ -7,194 +7,247 @@ import sys
 import time
 import unittest
 
-from flask import make_response
+from flask import make_response, request
+from collections import namedtuple
 
 from base import TestPluginBaseClass, test_app
+from minion.plugins.basic import CSPPlugin
 
-def _make_res(type, value):
+@test_app.route('/test')
+def endpoint():
+    headers = request.args.getlist("headers")
+    policy = request.args.get("policy", "default-src 'self';")
     res = make_response("")
-    if type.lower() == 'x':
-        res.headers['X-Content-Security-Policy'] = value
-    elif type.lower() == 'c':
-        res.headers['Content-Security-Policy'] = value
+
+    for h in headers:
+        _h = h.lower()
+        if _h == 'xcsp':
+            res.headers.add('X-Content-Security-Policy', policy)
+        elif _h == 'csp':
+            res.headers.add('Content-Security-Policy', policy)
+        elif _h == 'csp-ro':
+            res.headers.add('Content-Security-Policy-Report-Only', policy)
+        elif _h == "xcsp-ro":
+            res.headers['X-Content-Security-Policy-Report-Only'] = policy
     return res
-
-RULES = {'DEFAULT-SRC': "default-src 'self'",
-         "DEFAULT-SRC-DOMAIN": "default-src 'self' mydomain.com",
-         "DEFAULT-SRC-DOMAIN-SUB-DOMAIN": "default-src 'self' *.mydomain.com",
-         "DEFAULT-SRC-DOMAIN-SUB-DOMAIN-IMG-MEDIA-SCRIPT": 
-            "default-src 'self'; img-src *; media-src media1.com media2.com; script-src userscripts.example.com",
-         "EVAL": "script-src 'self' 'unsafe-eval' https://mydomain.com",
-         "INLINE": "script-src 'self' 'unsafe-inline' https://mydomain.com",
-         "BLOB": "default-src 'self' *.mega.co.nz http://*.mega.co.nz;" + 
-                 "script-src 'self' mega.co.nz data: blob:;",
-         "MALFORMED": "default-src 'selff'",
-}
-
-@test_app.route('/no-csp')
-def no_csp():
-    res = make_response()
-    return res
-
-@test_app.route('/default-src-self/<type>')
-def default_src_self(type):
-    return _make_res(type, RULES['DEFAULT-SRC'])
-
-@test_app.route('/default-src-self-trusted-domain/<type>')
-def default_src_self_trusted_domain(type):
-    return _make_res(type, RULES['DEFAULT-SRC-DOMAIN'])
-
-@test_app.route('/default-src-self-trusted-domain-subdomain/<type>')
-def default_src_self_trusted_domain_subdomain(type):
-    return _make_res(type, RULES['DEFAULT-SRC-DOMAIN-SUB-DOMAIN'])
-
-@test_app.route('/default-src-self-trusted-subdomain-all-img-some-media-some-script/<type>')
-def default_src_self_trusted_subdomain_all_img_some_media_some_script(type):
-    return _make_res(type, RULES['DEFAULT-SRC-DOMAIN-SUB-DOMAIN-IMG-MEDIA-SCRIPT'])
-
-@test_app.route('/malformed-csp')
-def malformed_csp():
-    return _make_res('c', RULES['MALFORMED'])
-
-@test_app.route('/eval-csp')
-def eval_csp():
-    return _make_res('x', RULES['EVAL'])
-
-@test_app.route('/inline-csp')
-def inline_csp():
-    return _make_res('x', RULES['INLINE'])
-
-@test_app.route('/dual-policy')
-def daul_policy():
-    resp = make_response('')
-    resp.headers['Content-Security-Policy'] = 'default-src *;'
-    resp.headers['Content-Security-Policy-Report-Only'] = 'default *;'
-    return resp
-
-@test_app.route('/report-only')
-def report_only():
-    resp = make_response('')
-    resp.headers['Content-Security-Policy-Report-Only'] = 'default *;'
-    return resp
-
-@test_app.route('/blob')
-def blog():
-    return _make_res('c', RULES['BLOB'])
-
+    
 class TestCSPPlugin(TestPluginBaseClass):
     __test__ = True
+    Issue = namedtuple('Issue', 'code summary severity')
+    CSP = CSPPlugin()
+
     @classmethod
     def setUpClass(cls):
         super(TestCSPPlugin, cls).setUpClass()
         cls.pname = 'CSPPlugin'
 
-    def validate_csp(self, runner_resp, request_resp, expected=None, expectation=True):
-        if expectation is True:
-            self.assertEqual('Info', runner_resp[1]['data']['Severity'])
-            self.assertEqual('Content-Security-Policy header set properly', runner_resp[1]['data']['Summary'])
-            self.assertEqual("The Content-Security-Policy header is set properly. Neither 'unsafe-inline' or \
-'unsafe-eval' is enabled.", runner_resp[1]['data']['Description'])
-            self.assertEqual('FINISHED', runner_resp[2]['data']['state'])
+    def _get_summary(self, key, fill_with=None):
+        _summary = self.CSP.REPORTS[key]['Summary']
+        if fill_with:
+            return _summary.format(**fill_with)
+        else:
+            return _summary
 
-        elif expectation == 'BOTH-SET':
-            self.assertEqual('Content-Security-Policy-Report-Only and Content-Security-Policy are set',
-                    runner_resp[1]['data']['Summary'])
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
+    def _run(self, headers=None, policy=None):
+        API = "http://localhost:1234/test"
+        r = requests.Request('GET', API, 
+            params={"headers": headers, "policy": policy}).prepare()
+        runner_resp = self.run_plugin(self.pname, r.url)
+        return runner_resp
 
-        elif expectation == 'REPORT-ONLY':
-            self.assertEqial('Content-Security-Policy-Report-Only does not enforce any CSP policy. Use \
-Content-Security-Policy to secure your site.', runner_resp[1]['data']['Description'])                    
-            self.assertEqual('Content-Security-Policy-Report-Only header set',
-                    runner_resp[1]['data']['Summary'])
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
+    def _get_issues(self, resps):
+        issues = []
+        for issue in resps:
+            if issue.get('data') and issue['data'].get('Code'):
+                _issue = self.Issue(issue['data']['Code'],
+                                    issue['data']['Summary'],
+                                    issue['data']['Severity'])
+                issues.append(_issue)
+        return issues
 
-        elif expectation is False:
-            self.assertEqual('No Content-Security-Policy header set',
-                    runner_resp[1]['data']['Summary'])
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
+    def _test_expecting_codes(self, issues, expects, message):
+        self.assertEqual(len(issues), len(expects), msg=message)
+        for expect in expects:
+            self._test_expecting_code(issues, expect, message)
 
-        elif expectation == 'INVALID':
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
-            self.assertEqual('Malformed Content-Security-Policy header is set', \
-                runner_resp[1]['data']['Summary'])
-            self.assertEqual('Malformed CSP header set: {value} does not seem like a valid source expression for {name}'.format(
-                value=expected['value'], name=expected['name']), runner_resp[1]['data']['Description'])
+    def _test_expecting_code(self, issues, expect, message):
+        codes = [issue.code for issue in issues]
+        self.assertEqual(True, expect in codes, msg=message)
+    
+    def _test_expecting_summary(self, issues, summary_name, message,
+            fill_with=None):
+        summaries = [issue.summary for issue in issues]
+        expecting_summary = self._get_summary(summary_name, fill_with=fill_with)
+        self.assertEqual(True, expecting_summary in summaries, msg=message)
 
-        elif expectation == 'UNSAFE-INLINE':
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
-            self.assertEqual("'unsafe-inline' is set in Content-Security-Policy header", \
-                runner_resp[1]['data']['Summary'])
+    # Start testing
+    # Testing pattern:
+    # 1. first assert the main issue is raised for that test
+    # 2. then assert other expecting issues
+    #
+    # NOTE: Good report should include {msg: start} and finish
+    #       which adds 2 to the total number of expected
+    #       issues returned in the response.
 
-        elif expectation == 'UNSAFE-EVAL':
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
-            self.assertEqual("'unsafe-eval' is set in Content-Security-Policy header", \
-                runner_resp[1]['data']['Summary'])
+    def test_csp(self):
+        resp = self._run(headers=['csp'])
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'csp-set',
+            "CSP is set should be in issues")
 
-        elif expectation is False:
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
-            self.assertEqual('No X-Content-Security-Policy header set"',
-                    runner_resp[1]['data']['Summary'])
-        """
-        elif expectation == 'EVAL-ENABLED':
-            self.assertEqual('CSP Rules allow unsafe-eval',
-                    runner_resp[1]['data']['Summary'])
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
+        self._test_expecting_codes(issues,
+            ['CSP-1', 'CSP-5'],
+            "Expecting CSP is set, XCSP is not set and number of unspecified directives")
 
-        elif expectation == 'INLINE-ENABLED':
-            self.assertEqual('CSP Rules allow unsafe-inline',
-                    runner_resp[1]['data']['Summary'])
-            self.assertEqual('High', runner_resp[1]['data']['Severity'])
-        """  
+    def test_no_csp_and_no_xcsp(self):
+        resp = self._run()
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'csp-not-set',
+            "CSP is not set should be in issues")
 
-    def test_no_csp(self):
-        api_name = '/no-csp'
-        self.validate_plugin(api_name, self.validate_csp, expectation=False)
+        self._test_expecting_codes(
+            issues,
+            ['CSP-2', 'CSP-5'],
+            "CSP is not set and XCSP is not set")
 
-    def test_x_default_src_self(self):
-        api_name= '/default-src-self/x'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_x_default_src_self_trusted_domain(self):
-        api_name = '/default-src-self-trusted-domain/x'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_x_default_src_self_trusted_domain_subdomain(self):
-        api_name = '/default-src-self-trusted-domain-subdomain/x'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_x_default_src_self_trusted_domain_subdomain_all_img_some_media_some_script(self):
-        api_name = '/default-src-self-trusted-subdomain-all-img-some-media-some-script/x'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
+    def test_only_csp_ro_only(self):
+        resp = self._run(headers=['csp-ro'])
+        issues = self._get_issues(resp)
 
-    def test_default_src_self(self):
-        api_name= '/default-src-self/c'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_default_src_self_trusted_domain(self):
-        api_name = '/default-src-self-trusted-domain/c'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_default_src_self_trusted_domain_subdomain(self):
-        api_name = '/default-src-self-trusted-domain-subdomain/c'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
-    def test_default_src_self_trusted_domain_subdomain_all_img_some_media_some_script(self):
-        api_name = '/default-src-self-trusted-subdomain-all-img-some-media-some-script/c'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
+        self._test_expecting_summary(
+            issues,
+            'csp-ro-only-set',
+            "CSP-Report-Only is set should be in issues")
 
-    def test_malformed_csp(self):
-        api_name = '/malformed-csp'
-        self.validate_plugin(api_name, self.validate_csp, expectation='INVALID',
-                expected={'value': "'selff'", 'name': 'default-src', 'hname': 'content-security-policy'})
-    def test_eval_csp(self):
-        api_name = '/eval-csp'
-        self.validate_plugin(api_name, self.validate_csp, expectation='UNSAFE-EVAL')
-    def test_inline_csp(self):
-        api_name = '/inline-csp'
-        self.validate_plugin(api_name, self.validate_csp, expectation='UNSAFE-INLINE')
+        self._test_expecting_codes(
+            issues,
+            ['CSP-2', 'CSP-3', 'CSP-5'],
+            "Expecting CSP is not set, CSP-RO is set and XCSP is not set")
 
-    def test_dual_policy(self):
-        api_name = '/dual-policy'
-        self.validate_plugin(api_name, self.validate_csp, expectation='BOTH-SET')
+    def test_only_xcsp_is_set(self):
+        resp = self._run(headers=['xcsp'])
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'xcsp-set',
+            "XCSP is set should be in issues")
 
-    def test_report_only(self):
-        api_name = '/report_only'
-        self.validate_plugin(api_name, self.validate_csp, expectation='REPORT_ONLY')
+        self._test_expecting_codes(
+            issues,
+            ['CSP-2', 'CSP-4'],
+            "Expecting CSP is not set and XCSP is set.")
 
-    def test_blob(self):
-        api_name = '/blob'
-        self.validate_plugin(api_name, self.validate_csp, expectation=True)
+    def test_only_xcsp_ro_only(self):
+        resp = self._run(headers=['xcsp-ro'])
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'xcsp-ro-only-set',
+            "XCSP-Report-Only is set should be in issues")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-2', 'CSP-5', 'CSP-6'],
+            "Expecting CSP and XCSP are not set but XCSP-RO is set")
+
+    def test_csp_and_csp_ro_are_set(self):
+        resp = self._run(headers=['csp', 'csp-ro'])
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'csp-csp-ro-set',
+            "Both CSP and CSP-Report-Only are set should be in issues")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-7'],
+            "Expecting CSP, CSP and CSP-RO are set but XCSP is not set")
+
+    def test_xcsp_and_xcsp_ro_are_set(self):
+        resp = self._run(headers=['xcsp', 'xcsp-ro'])
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'xcsp-xcsp-ro-set',
+            "Both XCSP and XCSP-Report-Only are set should be in issues")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-2', 'CSP-4', 'CSP-8'],
+            "Expecting XCSP, XCSP and XCSP-RO are set but CSP is not set")
+
+    def test_unknown_directive_in_csp_only_header(self):
+        resp = self._run(headers=['csp'],
+            policy="default-src 'self'; unknown-directive 'self';")
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'unknown-directive',
+            "1 unknown directive should be in issues",
+            fill_with={"count": 1})
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-9'],
+            "Expecting CSP is set, XCSP is not set and 1 unknown directive")
+
+    def test_csp_deprecated_directive(self):
+        resp = self._run(headers=['csp'],
+            policy="allow 'self'; xhr-src foobar.com;")
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'deprecated-directive',
+            "2 unknown directive should be in issues",
+            fill_with={"count": 2})
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-10'],
+            "Expecting CSP is set, XCSP is not set, 2 deprecated directives.")
+
+    def test_none_used_with_other_source_expressions(self):
+        resp = self._run(headers=['csp'],
+            policy="default-src 'self'; style-src 'self' 'none';")
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'bad-none',
+            "'none' issue should be in issue")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-11'],
+            "Expecting CSP is set, XCSP is not set, and improper use of 'none'")
+
+    def test_inline(self):
+        resp = self._run(headers=['csp'],
+            policy="default-src 'self'; style-src 'unsafe-inline';")
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'inline',
+            "unsafe-inline is enabled should be in issue")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-12'],
+            "Expecting CSP is set, XCSP is not set, and unsafe-inline is enabled")
+
+    def test_eval(self):
+        resp = self._run(headers=['csp'],
+            policy="default-src 'self'; script-src 'unsafe-eval';")
+        issues = self._get_issues(resp)
+        self._test_expecting_summary(
+            issues,
+            'eval',
+            "unsafe-eval is enabled should be in issue")
+
+        self._test_expecting_codes(
+            issues,
+            ['CSP-1', 'CSP-5', 'CSP-13'],
+            "Expecting CSP is set, XCSP is not set, and unsafe-eval is enabled")


### PR DESCRIPTION
What has changed?
- tests are completly rewritten.
- CSPPlugin is completely rewritten to support 1.0 syntax.
- Compare to the previous CSSPlugin, CSP and XCSP presence check is always required.

The orginal rewrite expected more issues to raise, but I have given up that idea, Instead,
only relevant and basic syntax checks are done. Issues/summaries like how many directives
inherit from default-src are not available (although they were implemented I backed out those
codes during squash). Also, this plugin currently only checks the syntax of the CSP header; so
XCSP, CSP-RO and XCSP-RO are not verified. An experimental CSPPlugin (but separate) should
be developed. Until then this plugin can remain simple like this.
