### PR TITLE
Fixed #296. In group creation, query site "url" not site "name".

### DIFF
--- a/minion/backend/views/groups.py
+++ b/minion/backend/views/groups.py
@@ -77,7 +77,7 @@ def create_group():
                 return jsonify(success=False, reason='user %s does not exist'%user)
     if sitez:
         for site in sitez:
-            if not sites.find_one({'name': site}):
+            if not sites.find_one({'url': site}):
                 return jsonify(success=False, reason='site %s does not exist'%site)
 
     if groups.find_one({'name': group['name']}) is not None:

--- a/tests/functional/views/test_invites.py
+++ b/tests/functional/views/test_invites.py
@@ -351,8 +351,6 @@ class TestInviteAPIs(TestAPIBaseClass):
         site = Site(self.target_url)
         res2 = site.create()
 
-        # NOTE: Uncomment the following checks when #296 is resolved.
-        """
         # create a group in minion
         group = Group(self.group_name, sites=[site.url], users=[recipient.email])
         group.create()
@@ -390,4 +388,3 @@ class TestInviteAPIs(TestAPIBaseClass):
         res8 = group.get()
         self.assertEqual(res8.json()["group"]["sites"], [site.url])
         self.assertEqual(res8.json()["group"]["users"], [recipient_2.email])
-        """

--- a/tests/functional/views/test_scans.py
+++ b/tests/functional/views/test_scans.py
@@ -67,8 +67,6 @@ class TestScanAPIs(TestAPIBaseClass):
             for name in ('queued', 'started', 'finished', 'progress'):
                 self.assertEqual(session[name], None)
 
-    # NOTE: Uncomment when #296 is fixed.
-    """
     def test_get_scan_details(self):
         scan = Scan(self.user.email, self.TEST_PLAN["name"], {"target": self.target_url})
         res1 = scan.create()
@@ -81,7 +79,6 @@ class TestScanAPIs(TestAPIBaseClass):
         # bug #140 and bug #146
         res3 = scan.get_scan_details(scan_id, email=self.user.email)
         self.assertEqual(res3.json(), res2.json())
-    """
 
     # bug #140 and bug #146
     def test_get_scan_details_filter_with_nonexistent_user(self):
@@ -110,8 +107,8 @@ class TestScanAPIs(TestAPIBaseClass):
         self.assertEqual(res2.json()["success"], False)
         self.assertEqual(res2.json()["reason"], "not-found")
 
-    # NOTE: Uncomment this when #296 is fixed
-    ''' 
+    # NOTE: Uncomment this once #299 is fixed.
+    '''
     def test_scan(self):
         """
         This is a comprehensive test that runs through the following


### PR DESCRIPTION
We mistakenly query the wrong (and non-existient) attribute
in the sites collection. The correct name is "url", not "name".
