### PR TITLE
Fixed #298. Handle non-existent plan in GET /plans/<plan_name>

### DIFF
--- a/minion/backend/views/plans.py
+++ b/minion/backend/views/plans.py
@@ -229,7 +229,10 @@ def update_plan(plan_name):
 @permission
 def get_plan(plan_name):
     plan = get_plan_by_plan_name(plan_name)
-    # Fill in the details of the plugin
-    for step in plan['workflow']:
-        plugin = plugins.get(step['plugin_name'])
-    return jsonify(success=True, plan=sanitize_plan(plan))
+    if plan:
+        # Fill in the details of the plugin
+        for step in plan['workflow']:
+            plugin = plugins.get(step['plugin_name'])
+        return jsonify(success=True, plan=sanitize_plan(plan))
+    else:
+        return jsonify(success=False, reason="Plan does not exist")

--- a/tests/functional/views/test_plans.py
+++ b/tests/functional/views/test_plans.py
@@ -104,14 +104,15 @@ class TestPlanAPIs(TestAPIBaseClass):
         plan = Plan(self.TEST_PLAN)
         res1 = plan.create()
         self.assertEqual(res1.json()["success"], True)
+
         # Delete the plan
         res2 = plan.delete(self.TEST_PLAN["name"])
         self.assertEqual(res2.json()["success"], True)
-        # NOTE: Fix this whne #298 is fixed
+
         # Make sure the plan is gone
-        # res3 = plan.get(self.TEST_PLAN["name"])
-        # self.assertEqual(res3.json()["success"], False)
-        # self.assertEqual(res3.json()["reason"], "Plan does not exist.")
+        res3 = plan.get(self.TEST_PLAN["name"])
+        self.assertEqual(res3.json()["success"], False)
+        self.assertEqual(res3.json()["reason"], "Plan does not exist")
 
     def test_delete_nonexistent_plan(self):
         plan = Plan(None)


### PR DESCRIPTION
If the plan does not exist, we should return False.
We should probably handle with a 404 in the future.
