### PR TITLE
Fixed #297. Allow to filter plans by passing email to the filter.

### DIFF
--- a/minion/backend/views/plans.py
+++ b/minion/backend/views/plans.py
@@ -41,7 +41,7 @@ def _check_plan_by_email(email, plan_name):
 
 def get_plans_by_email(email):
     plans = get_sanitized_plans()
-    matched_plans = [plan for plan in plans if _check_plan_by_email(email)]
+    matched_plans = [plan for plan in plans if _check_plan_by_email(email, plan["name"])]
     return matched_plans
 
 def permission(view):
@@ -134,7 +134,7 @@ def get_plans():
             plans = get_plans_by_email(email)
         else:
             plans = get_sanitized_plans()
-            return jsonify(success=True, plans=plans)
+        return jsonify(success=True, plans=plans)
 
 #
 # Delete an existing plan

--- a/tests/functional/views/test_invites.py
+++ b/tests/functional/views/test_invites.py
@@ -65,7 +65,6 @@ class TestInviteAPIs(TestAPIBaseClass):
         site_id = res2.json()["site"]["id"]
 
         # Uncomment the following checks when #297 is resolved.
-        """
         # create a group in minion
         group = Group(self.group_name, sites=[site.url], users=[recipient.email])
         res3 = group.create()
@@ -82,7 +81,6 @@ class TestInviteAPIs(TestAPIBaseClass):
         res6 = recipient.get()
         self.assertEqual(res6.json()["user"]["sites"], [site.url])
         self.assertEqual(res6.json()["user"]["groups"], [group.group_name])
-        """
 
     def test_invite_an_existing_user(self):
         sender = User(self.email)

--- a/tests/functional/views/test_plans.py
+++ b/tests/functional/views/test_plans.py
@@ -20,14 +20,17 @@ class TestPlanAPIs(TestAPIBaseClass):
         """
 
         _plan = plan or self.TEST_PLAN
+        self.plan = Plan(_plan)
+        resp = self.plan.create()
+
         self.user = User(self.email)
         self.user.create()
-        self.site = Site(self.target_url)
+        self.site = Site(self.target_url, plans=[self.plan.plan["name"]])
         self.site.create()
         self.group = Group("testgroup", sites=[self.site.url], users=[self.user.email])
         self.group.create()
         self.plan = Plan(_plan)
-        return self.plan.create()
+        return resp
 
     def _assert_test_plan(self, plan):
         self.assertEqual("test", plan["name"])
@@ -55,14 +58,11 @@ class TestPlanAPIs(TestAPIBaseClass):
         self.assertEqual(len(resp.json()["plans"]), 1)
         self._assert_test_plan(resp.json()["plans"][0])
 
-    #NOTE: Wait until #297 is resolved
-    """
     def test_find_all_plans_registered_under_an_email(self):
         self._create_plan()
         resp = Plans().get(email=self.user.email)
         self.assertEqual(len(resp.json()["plans"]), 1)
         self._assert_test_plan(resp.json()["plans"][0])
-    """
 
     def test_create_invalid_plugin_plan(self):
         # Check /plans return invalid-plan-exists when plugin is not


### PR DESCRIPTION
The issue occurs that we didn't pass the second argument the plan name
into _check_plan_by_email().

Though the code is not very efficient. See #304.
