### PR TITLE
Consideration of CIDR Network in Minion

### DIFF
--- a/minion/backend/utils.py
+++ b/minion/backend/utils.py
@@ -13,7 +13,7 @@ import os
 import socket
 import smtplib
 import urlparse
-import netaddr
+from netaddr import IPNetwork, IPAddress
 from email.mime.text import MIMEText
 
 DEFAULT_WHITELIST = []
@@ -84,8 +84,7 @@ def scannable(target, whitelist=[], blacklist=[]):
 
     def match(address, networks):
         for network in networks:
-            network = ipaddress.IPv4Network(unicode(network))
-            if ipaddress.IPv4Address(unicode(address)) in network:
+            if IPAddress(address) in IPNetwork(network):
                 return True
 
     #
@@ -96,7 +95,7 @@ def scannable(target, whitelist=[], blacklist=[]):
     #
 
     try:
-        cidr = netaddr.IPNetwork(target)
+        cidr = IPNetwork(target)
 
         for address in list(cidr):
             if match(str(address), whitelist):
@@ -115,16 +114,16 @@ def scannable(target, whitelist=[], blacklist=[]):
     url = urlparse.urlparse(target)
 
     #
-    # Resolve the url's hostname to a list of IPv4 addresses. The getaddrinfo()
+    # Resolve the url's hostname to a list of IPv4 and IPV6 addresses. The getaddrinfo()
     # call is not ideal and should be replaced with a real dns module.
     #
 
     addresses = []
 
-    infos = socket.getaddrinfo(url.hostname, None, socket.AF_INET, socket.SOCK_STREAM,
+    infos = socket.getaddrinfo(url.hostname, None, 0, socket.SOCK_STREAM,
                                socket.IPPROTO_IP, socket.AI_CANONNAME)
     for info in infos:
-        if info[0] == socket.AF_INET:
+        if info[0] == socket.AF_INET or info[0] == socket.AF_INET6:
             addresses.append(info[4][0])
 
     #

--- a/minion/backend/views/sites.py
+++ b/minion/backend/views/sites.py
@@ -14,7 +14,7 @@ from minion.backend.views.plans import _check_plan_exists
 def _check_site_url(url):
     regex = re.compile(r"^((http|https)://(localhost|([a-z0-9][-a-z0-9]*)(\.[a-z0-9][-a-z0-9]*)+)(:\d+)?)"
                        r"|"
-                       r"((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2])))$")
+                       r"((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2]))?)$")
     return regex.match(url) is not None
 
 #def _check_required_fields(expected, fields):

--- a/minion/backend/views/sites.py
+++ b/minion/backend/views/sites.py
@@ -12,7 +12,9 @@ from minion.backend.views.groups import _check_group_exists
 from minion.backend.views.plans import _check_plan_exists
 
 def _check_site_url(url):
-    regex = re.compile(r"^(http|https)://(localhost|([a-z0-9][-a-z0-9]*)(\.[a-z0-9][-a-z0-9]*)+)(:\d+)?$")
+    regex = re.compile(r"^((http|https)://(localhost|([a-z0-9][-a-z0-9]*)(\.[a-z0-9][-a-z0-9]*)+)(:\d+)?)"
+                       r"|"
+                       r"((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])(\/(\d|[1-2]\d|3[0-2])))$")
     return regex.match(url) is not None
 
 #def _check_required_fields(expected, fields):

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     'pycurl==7.19.0',
     'gunicorn==0.17.4',
     'ipaddress==1.0.4',
-    'netaddr==0.7.11',
+    'netaddr>=0.7.11',
 ]
 
 plugins_requires = [

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     'pycurl==7.19.0',
     'gunicorn==0.17.4',
     'ipaddress==1.0.4',
+    'netaddr==0.7.11',
 ]
 
 plugins_requires = [

--- a/tests/functional/views/test_sites.py
+++ b/tests/functional/views/test_sites.py
@@ -57,6 +57,37 @@ class TestSitesAPIs(TestAPIBaseClass):
         self.assertEqual(res2.json()['success'], False)
         self.assertEqual(res2.json()['reason'], 'site-already-exists')
 
+    def test_create_site_with_ip(self):
+        group = Group(self.group_name)
+        group.create()
+
+        site = Site("127.0.0.1", groups=[group.group_name])
+        res = site.create()
+        self.assertEqual(set(res.json()['site'].keys()),
+            set(self.expected_inner_keys))
+        self.assertEqual(res.json()['site']['url'], site.url)
+        self.assertEqual(res.json()['site']['plans'], [])
+
+    def test_create_site_with_cidr_network(self):
+        group = Group(self.group_name)
+        group.create()
+
+        site = Site("127.0.0.1/24", groups=[group.group_name])
+        res = site.create()
+        self.assertEqual(set(res.json()['site'].keys()),
+            set(self.expected_inner_keys))
+        self.assertEqual(res.json()['site']['url'], site.url)
+        self.assertEqual(res.json()['site']['plans'], [])
+
+    def test_create_site_with_bad_format(self):
+        group = Group(self.group_name)
+        group.create()
+
+        site = Site("http://badsite", groups=[group.group_name])
+        res = site.create()
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(res.json()['reason'], 'invalid-url')
+
     def test_get_all_sites(self):
         group = Group(self.group_name)
         group.create()


### PR DESCRIPTION
It was not possible to add CIDR Network in Minion. It was missing, for example, for the NMAP plugin.