### PR TITLE
Added consideration of environment variables for external process

### DIFF
--- a/minion/plugins/base.py
+++ b/minion/plugins/base.py
@@ -263,7 +263,7 @@ class ExternalProcessPlugin(AbstractPlugin):
         protocol = ExternalProcessProtocol(self)
         name = path.split('/')[-1]
         logging.debug("Executing %s %s" % (path, " ".join([name] + arguments)))
-        self.process = reactor.spawnProcess(protocol, path, [name] + arguments)
+        self.process = reactor.spawnProcess(protocol, path, [name] + arguments, None)
 
     def do_process_ended(self, status):
         logging.debug("ExternalProcessPlugin.do_process_ended")


### PR DESCRIPTION
Minion was not taking consideration of environment variables when we call an external process with a plugin so we had the option
