### PR TITLE
add in a docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM ubuntu
+RUN sudo apt-get update
+RUN sudo apt-get install -y \
+    build-essential \
+    curl \
+    git \
+    libcurl4-openssl-dev \
+    libffi-dev \
+    mongodb-server \
+    postfix \
+    python \
+    python-dev \
+    python-setuptools \
+    rabbitmq-server \
+    stunnel4 \
+    nmap \
+    supervisor
+
+RUN easy_install --upgrade setuptools
+
+RUN install -m 700 -o mongodb -g mongodb -d /data/db
+RUN useradd -m minion-backend
+RUN install -m 700 -o minion-backend -g minion-backend -d /run/minion -d /var/lib/minion -d /var/log/minion
+
+# Somewhere to store the eggs since there's no need to use virtual envs.
+ENV PYTHON_EGG_CACHE /tmp
+
+COPY . /srv/minion
+WORKDIR /srv/minion
+# Normally we'd only copy over requirements and use that, but without
+# an explicit requirements.txt file, we have to copy over the whole thing.
+RUN python setup.py develop

--- a/etc/docker.supervisor.conf
+++ b/etc/docker.supervisor.conf
@@ -1,0 +1,18 @@
+[supervisord]
+logfile=/var/log/supervisord.log
+
+[include]
+files=/srv/minion/etc/minion-backend.supervisor.conf \
+    /srv/minion/etc/minion-plugin-worker.supervisor.conf \
+    /srv/minion/etc/minion-scan-worker.supervisor.conf \
+    /srv/minion/etc/minion-state-worker.supervisor.conf
+
+[program:mongodb]
+command=mongod --smallfiles
+user=root
+
+[inet_http_server]
+port=9001
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface

--- a/etc/minion-backend.supervisor.conf
+++ b/etc/minion-backend.supervisor.conf
@@ -1,6 +1,6 @@
 [program:minion-backend]
 
-command=gunicorn -b 127.0.0.1:8383 -w 4 minion.backend.wsgi:app
+command=gunicorn -b 0.0.0.0:8383 -w 4 minion.backend.wsgi:app
 
 numprocs=1                    ; number of processes copies to start (def 1)
 directory=/tmp/               ; directory to cwd to before exec (def no cwd)
@@ -20,4 +20,3 @@ stdout_logfile_backups=10
 stderr_logfile=/var/log/supervisor/minion-backend.stderr.log
 stderr_logfile_maxbytes=1MB
 stderr_logfile_backups=10
-


### PR DESCRIPTION
To go along with the pull request on minion-frontend, not ready to go yet will need docker-compose. Also this changes minion to not listen on an internal interface so that the two docker containers will talk to each other.

If this is of interest and lands, i'd improve by splitting out mongodb and rabbitmq into seperate services, running everything in one is kinda icky.

Anyway lets see if I can get all this running first.