### PR TITLE
Make scanning work again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup_requires = [
 
 install_requires = [
     'six>=1.7',
-    'celery>=3.0.19',
+    'celery==3.0.19',
     'flask>=0.9',
     'pymongo==2.8.1', # bug in 3.0 causes false ConnectionError; fixed in trunk, TODO update once fixed
     'requests>=1.2.2',
@@ -19,7 +19,7 @@ install_requires = [
     'gunicorn>=0.17.4',
     'ipaddress>=1.0.4',
     'netaddr>=0.7.11',
-    'celerybeat-mongo>=0.0.5'
+    'celerybeat-mongo==0.0.5'
 ]
 
 plugins_requires = [

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup_requires = [
 
 install_requires = [
     'six>=1.7',
-    'celery==3.0.19',
+    'celery==3.1.25',
     'flask>=0.9',
     'pymongo==2.8.1', # bug in 3.0 causes false ConnectionError; fixed in trunk, TODO update once fixed
     'requests>=1.2.2',
@@ -19,7 +19,7 @@ install_requires = [
     'gunicorn>=0.17.4',
     'ipaddress>=1.0.4',
     'netaddr>=0.7.11',
-    'celerybeat-mongo==0.0.5'
+    'celerybeat-mongo>=0.1.0'
 ]
 
 plugins_requires = [


### PR DESCRIPTION
Hey there!

Since Celery ~4.0.0 runtime warnings about [retrieving task result inside another task](https://github.com/mozilla/minion-backend/blob/master/minion/backend/tasks.py#L425) became errors.
This PR downgrades celery version and is not the best option of course, but I hope somebody will find it useful.

Cheers